### PR TITLE
UX: fix tag sidebar, settings, timeline, etc

### DIFF
--- a/javascripts/discourse/components/sidebar-about-tag.hbs
+++ b/javascripts/discourse/components/sidebar-about-tag.hbs
@@ -5,43 +5,33 @@
     {{did-insert this.getTagNotificationLevel}}
     {{did-update this.getTagNotificationLevel this.tagId}}
   >
-    {{#if (or this.tag.description this.currentUser)}}
-      <div class="custom-right-sidebar_tag-about">
-        {{#if this.tag.description}}
-          <h3>{{theme-i18n "about_tag"}}</h3>
-          <p>{{html-safe this.tag.description}}</p>
-        {{else}}
-          {{#if this.currentUser.admin}}
-            <h3>{{theme-i18n "about_admin_tip_headline"}}</h3>
-            <p>
-
-              {{html-safe this.linkedDescription}}
-              <a {{on "click" this.toggleInfo}} href>
-                {{theme-i18n "about_tag_admin_tip_description_link"}}</a>
-            </p>
+    {{#if this.shouldShow}}
+      {{#if (or this.tag.description this.currentUser)}}
+        <div class="custom-right-sidebar_tag-about">
+          {{#if this.tag.description}}
+            <h3>{{theme-i18n "about_tag"}}</h3>
+            <p>{{html-safe this.tag.description}}</p>
           {{/if}}
-        {{/if}}
-        {{#if this.currentUser}}
-          <div class="custom-right-sidebar_controls">
-            {{#if this.currentUser.can_create_topic}}
-              <DButton
-                class="btn-default"
-                @id="custom-create-topic"
-                @action={{action "customCreateTopic"}}
-                @icon="plus"
-                @translatedLabel={{i18n "topic.create"}}
+          {{#if this.currentUser}}
+            <div class="custom-right-sidebar_controls">
+              {{#if this.currentUser.can_create_topic}}
+                <DButton
+                  class="btn-default"
+                  @id="custom-create-topic"
+                  @action={{action "customCreateTopic"}}
+                  @icon="plus"
+                  @translatedLabel={{i18n "topic.create"}}
+                />
+              {{/if}}
+              <TagNotificationsButton
+                @onChange={{this.changeTagNotificationLevel}}
+                @value={{this.tagNotification.notification_level}}
               />
-            {{/if}}
-
-            <TagNotificationsButton
-              @onChange={{this.changeTagNotificationLevel}}
-              @value={{this.tagNotification.notification_level}}
-            />
-
-            <AddToSidebar @tag={{this.tag}} @category={{this.category}} />
-          </div>
-        {{/if}}
-      </div>
+              <AddToSidebar @tag={{this.tag}} @category={{this.category}} />
+            </div>
+          {{/if}}
+        </div>
+      {{/if}}
     {{/if}}
   </div>
 {{/if}}

--- a/javascripts/discourse/components/sidebar-about-tag.js
+++ b/javascripts/discourse/components/sidebar-about-tag.js
@@ -15,6 +15,10 @@ export default class SidebarAboutTag extends Component {
   @tracked tag = null;
   @tracked tagNotification = null;
 
+  get shouldShow() {
+    return this.tag && !this.category;
+  }
+
   get tagId() {
     return this.router.currentRoute.params?.tag_id;
   }

--- a/javascripts/discourse/components/sidebar-latest-topics.hbs
+++ b/javascripts/discourse/components/sidebar-latest-topics.hbs
@@ -8,6 +8,7 @@
         but using that component directly was causing 
         eyeline issues with loading more topics on }}
     <div class="custom-right-sidebar_recent-topics-wrappper">
+      {{! template-lint-disable no-nested-interactive }}
       <a
         class="custom-topic-layout"
         href="{{topic.url}}/{{topic.last_read_post_number}}"

--- a/javascripts/discourse/components/sidebar-latest-topics.hbs
+++ b/javascripts/discourse/components/sidebar-latest-topics.hbs
@@ -8,7 +8,10 @@
         but using that component directly was causing 
         eyeline issues with loading more topics on }}
     <div class="custom-right-sidebar_recent-topics-wrappper">
-      <div class="custom-topic-layout">
+      <a
+        class="custom-topic-layout"
+        href="{{topic.url}}/{{topic.last_read_post_number}}"
+      >
         <div class="custom-topic-layout_meta">
           {{#unless this.hideCategory}}
             {{#unless topic.isPinnedUncategorized}}
@@ -61,7 +64,7 @@
             {{i18n "post.quote_share"}}
           </span>
         </div>
-      </div>
+      </a>
 
     </div>
   {{/each}}

--- a/scss/right-sidebar.scss
+++ b/scss/right-sidebar.scss
@@ -58,6 +58,9 @@
       display: flex;
       flex-wrap: wrap;
       gap: 0.25em;
+      a {
+        display: flex;
+      }
     }
   }
 

--- a/scss/topic-list.scss
+++ b/scss/topic-list.scss
@@ -10,7 +10,8 @@ body.category,
 
     #create-topic,
     .select-kit.single-select.dropdown-select-box.notifications-button,
-    .topic-drafts-menu-trigger {
+    .topic-drafts-menu-trigger,
+    .notifications-tracking-trigger {
       display: none;
     }
   }
@@ -34,10 +35,6 @@ body.category,
   @include custom-card;
   text-align: center;
   padding: 2.5em 3em 2em;
-}
-
-#header-list-area {
-  display: none;
 }
 
 .category-heading {

--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -70,6 +70,7 @@
 
 .timeline-container.timeline-docked-bottom .timeline-footer-controls {
   opacity: 1;
+  pointer-events: all; // overrides core
 }
 
 .timeline-container .topic-timeline .timeline-scrollarea {
@@ -216,10 +217,10 @@ html:not(.footer-nav-visible) #topic-progress-wrapper {
 }
 
 .container.posts {
-  #topic-progress {
+  #topic-progress-wrapper #topic-progress {
     border: 1px solid var(--primary-400);
     .nums {
-      top: 0.65em;
+      top: 0.1em;
     }
   }
   #topic-progress-wrapper {


### PR DESCRIPTION
This fixes a few issues reported here: https://meta.discourse.org/t/a-reddit-ish-theme-for-discourse/269466/90?u=awesomerobot

* Allows this tag info to show: 

  ![image](https://github.com/user-attachments/assets/d20d277b-4f0a-4fd1-9256-cb830e8ae3b7)

* Fixes an issue where the topic timeline buttons weren't clickable when docked 

* Fixes an issue where some category sidebar data would appear on tag routes, and it wouldn't be functional 

* Makes the full recent topic blocks clickable, rather than just the title 

* Removes some extra whitespace from tags in the sidebar 