### PR TITLE
UX: hide stray composer border when closed

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -197,6 +197,9 @@ html:not(.footer-nav-visible) #topic-progress-wrapper {
       font-size: var(--font-up-1);
     }
   }
+  &.closed {
+    border: none;
+  }
 }
 
 .alert.alert-info.clickable {


### PR DESCRIPTION
this removes a stray line from the `#reply-area` div when the composer is closed:

![image](https://github.com/user-attachments/assets/be9a108a-8d16-4d6d-8412-2846b3751c01)
