### PR TITLE
UX: override topic body width

### DIFF
--- a/scss/composer.scss
+++ b/scss/composer.scss
@@ -106,3 +106,7 @@
     transform: scale(75%);
   }
 }
+
+#reply-control:not(.fullscreen).hide-preview {
+  --topic-body-width: 690px;
+}


### PR DESCRIPTION
This theme overrides `topic-body-width`, which can cause the composer to overflow when in the hide preview state.

The proposed fix is to reset the variable to the default value local to the element replay control in hide preview state.

Context: https://dev.discourse.org/t/fix-rich-text-editor-composer-overflow-in-themes/160089